### PR TITLE
Sethmott

### DIFF
--- a/lab03.2-compare_and_choose_models/0_README.md
+++ b/lab03.2-compare_and_choose_models/0_README.md
@@ -9,140 +9,150 @@ In this lab we will focus on how to use Workbench to facilitate model selection.
 
 ## Praparing Workbench and running a single experiment
 
-1. Open the Workbench and create a new project called `classifying_iris`. Choose the **Classifying Iris** as the project template and `Documents` folder as its directory. Open the project and go to **File > Open Command Prompt** to access the command line from within the project parent folder. 
-2. Run `az group create -n azurebootcamplab32 -l eastus2` to create a resource group called `azurebootcamplab32` for the resources we will provision throughout this lab. Then run the following command to create an Azure ML Experimentation account, a Model Management account, and a Workspace.
-```
-az storage account create -n azurebootcampeastus2 -g azurebootcamplab32 --sku Standard_LRS
-az group deployment create -g azurebootcamplab32 --template-file template-azml.json --parameters @parameters-azml.json
-```
-In case the deployment results in an error message coded `RoleAssignmentUpdateNotPermitted`, we can safely ignore it as long as the assets `azureuseramlexp`, `azureuseramlws` and `azureuseramlmm` were added to the resource group. We can check all the resources under a resource group from the portal or by running `az resource list -g azurebootcamplab32 -o table`.  
-FYI, as an alternative, we can also create the above from the Azure portal by navigating to [this link](https://docs.microsoft.com/en-us/azure/machine-learning/preview/quickstart-installation) and completing the section **Create Azure Machine Learning accounts**.
-3. From the command prompt, run the following command to submit the training experiment: 
+Open the Workbench and create a new project called `classifying_iris`. Choose the **Classifying Iris** as the project template and `Documents` folder as its directory. Open the project and go to **File > Open Command Prompt** to access the command line from within the project parent folder.
+
+Launch Docker and wait for it to be running. From the command prompt, run the following command to submit the training experiment:
+
 ```
 az ml experiment submit -c docker-python iris_sklearn.py
 ```
+
 This runs a single training experiment. If we are doing this for the first time, then prior to running the experiment Workbench will create a docker image for us, which will take a few minutes. Once the image is ready, as long as we use the same image, we can run experiments on it quickly and without the initial delay. 
 **Note:** At this point, there is a strange Docker behavior for which we propose an easy solution: we may get an error at the top about `image operating system "linux" cannot be used on this platform`.
 
-   ![](./images/linux-image-not-found.jpg){:width="500px"}
+![](./images/linux-image-not-found.jpg){:width="500px"}
 
-   To resolve it we click on the Docker logo on the right-hand side in the taskbar and switch Docker to use Windows containers. This will result in a new Docker error:
+To resolve it we click on the Docker logo on the right-hand side in the taskbar and switch Docker to use Windows containers. This will result in a new Docker error:
 
-   ![](./images/docker-windows-image.jpg){:width="400px"}
+![](./images/docker-windows-image.jpg){:width="400px"}
 
-   Now we switch Docker back to Linux containers (by going to the taskbar once more).
+Now we switch Docker back to Linux containers (by going to the taskbar once more).
 
-   ![](./images/switch-linux-containers.jpg){:width="300px"}
+![](./images/switch-linux-containers.jpg){:width="300px"}
 
-   We then return to the command prompt and run the above command again.
+We then return to the command prompt and run the above command again.
 
 ## Running multiple experiments
 
-4. Go to **File > Open Project (Code)** to edit the project scripts using Code. Open the script called `iris_sklearn.py`. Go to lines 45-48 and examine the code snippet there. We use the `sys.argv` function to pass extra arguments to Python when we run it from the command line. In our script, we have an optional regularization parameter that we can declare when we before running the experiment (otherwise it defaults to the value in line 45).
-5. We will now run multiple experiments in order to perform model selection. Each experiment will consist of a model with a different regularization parameter. To make it easier to iterate over the different vaules of the regularization parameter, we have the short script called `run.py` with creates a list of regularization parameters we want to iterate over and then runs the same `az ml experiment submit` command we ran earlier, but this time with the regularization parameter explicitly passed as well. Open `run.py` in Code and change `local` to `docker-python` in line 9. Save the change.
-6. Return to the command line and run `python run.py` to run multiple experiments. As the experiments are running, return to the Workbench and open the **Jobs** pannel on the right-hand side and monitor jobs as they're running.
-    
-   ![](./images/jobs-pannel.jpg){:height="300px"}
+Go to **File > Open Project (Code)** to edit the project scripts using Code. Open the script called `iris_sklearn.py`. Go to lines 45-48 and examine the code snippet there. We use the `sys.argv` function to pass extra arguments to Python when we run it from the command line. In our script, we have an optional regularization parameter that we can declare when we before running the experiment (otherwise it defaults to the value in line 45).
 
-   Click on the green **Completed** button for one of the jobs to examine the logs created by the script.
-7. Once all the jobs finish running, go to the the **Runs** tab on the left-hand side and click on **All Runs**. Then examine the metrics and visualizations we are presented with.
+We will now run multiple experiments in order to perform model selection. Each experiment will consist of a model with a different regularization parameter. To make it easier to iterate over the different vaules of the regularization parameter, we have the short script called `run.py` with creates a list of regularization parameters we want to iterate over and then runs the same `az ml experiment submit` command we ran earlier, but this time with the regularization parameter explicitly passed as well. Open `run.py` in Code and change `local` to `docker-python` in line 9. Save the change.
 
-   ![](./images/runs-tab.jpg){:height="300px"}
-  
-   At the top we have four pannels, one showing information about the jobs we ran and the other three showing some metrics collected by each run (a run here is a single experiment).
+Return to the command line and run `python run.py` to run multiple experiments. As the experiments are running, return to the Workbench and open the **Jobs** pannel on the right-hand side and monitor jobs as they're running. Click on the green **Completed** button for one of the jobs to examine the logs created by the script.
 
-   ![](./images/top-four-pannel.jpg){:height="700px"}
+![](./images/jobs-pannel.jpg){:height="300px"}
 
-   To see how these metrics tie back to the Python script, open `iris_sklearn.py` in **Code** and find where the model's accuracy is being logged. Hint: the Python object storing it is called `accuracy` in the script. 
-8. Note that we have two ways of logging information in Workbench: 
-   - We can simply rely on Python's `print` function, as can be seen by `print("Accuracy is {}".format(accuracy))` for example. In such a case, we can go the the **Jobs** pannel and click on the green **Completed** button to see any printed logs for a given run.
+Once all the jobs finish running, go to the the **Runs** tab on the left-hand side and click on **All Runs**. Then examine the metrics and visualizations we are presented with.
 
-   ![](./images/click-completed.jpg){:height="600px"}
-   - We can rely on the `get_azureml_logger` method to instantiate a logger object and use it to log information, such as in `run_logger.log("Accuracy", accuracy)`. This produces the accuracy chart from the **Runs** tab.
+![](./images/runs-tab.jpg){:height="300px"}
   
-   ![](./images/accuracy-chart.jpg){:height="400px"}
+At the top we have four pannels, one showing information about the jobs we ran and the other three showing some metrics collected by each run (a run here is a single experiment).
+
+![](./images/top-four-pannel.jpg){:height="700px"}
+
+To see how these metrics tie back to the Python script, open `iris_sklearn.py` in **Code** and find where the model's accuracy is being logged. Hint: the Python object storing it is called `accuracy` in the script. 
+
+Note that we have two ways of logging information in Workbench: 
+
+- We can simply rely on Python's `print` function, as can be seen by `print("Accuracy is {}".format(accuracy))` for example. In such a case, we can go the the **Jobs** pannel and click on the green **Completed** button to see any printed logs for a given run.
+
+![](./images/click-completed.jpg){:height="600px"}
+
+- We can rely on the `get_azureml_logger` method to instantiate a logger object and use it to log information, such as in `run_logger.log("Accuracy", accuracy)`. This produces the accuracy chart from the **Runs** tab.
   
-   The biggest advantage of this second approach is that the chart has an interactive component to it. For example, we can click on the chart to select the point with the highest accuracy and as we do so, the corresponding run is automatically selected and we can examine its content by clicking on it.
+![](./images/accuracy-chart.jpg){:height="400px"}
   
-   ![](./images/highest-accuracy.jpg){:height="700px"}
+The biggest advantage of this second approach is that the chart has an interactive component to it. For example, we can click on the chart to select the point with the highest accuracy and as we do so, the corresponding run is automatically selected and we can examine its content by clicking on it.
   
-   We can also hold down **CTRL** and click on the next run with the highest accuracy and once again as we do so the run is automatically selected for us. With two or more selected runs, we can now click on **Compare** to compare them across various metrics.
+![](./images/highest-accuracy.jpg){:height="700px"}
   
-   ![](./images/runs-table.jpg){:height="700px"}
+We can also hold down **CTRL** and click on the next run with the highest accuracy and once again as we do so the run is automatically selected for us. With two or more selected runs, we can now click on **Compare** to compare them across various metrics.
   
-   This allows us to compare meta-data between runs, any metrics we collected using the `get_azureml_logger` method, as well as any visualizations created by the Python script as part of the run.
+![](./images/runs-table.jpg){:height="700px"}
+  
+This allows us to compare meta-data between runs, any metrics we collected using the `get_azureml_logger` method, as well as any visualizations created by the Python script as part of the run.
 
 ## Logging new metrics 
 
 We now add two new metrics to the logger in the `iris_sklearn.py` script, then rerun the experiments to see the additional output that is created as a result.
 
-1. Since the training experiment `iris_sklearn.py` keeps track on precision and recall, we can use those to find the **F-score** which is a sort of average of precision and recall. In our script, the variables `precision` and `recall` are not single numbers but arrays. This is because obtain a different precision and recall by changing our probability threshold for being classified as positive. Similarly, we obtain an array of F-scores by using different threshold values, so we will also log the maximum F-score value (a single number). In **Code** paste in the below code snippet after line 71 in `iris_sklearn.py`, then save the script.
+Since the training experiment `iris_sklearn.py` keeps track on precision and recall, we can use those to find the **F-score** which is a sort of average of precision and recall. In our script, the variables `precision` and `recall` are not single numbers but arrays. This is because obtain a different precision and recall by changing our probability threshold for being classified as positive. Similarly, we obtain an array of F-scores by using different threshold values, so we will also log the maximum F-score value (a single number). In **Code** paste in the below code snippet after line 71 in `iris_sklearn.py`, then save the script.
+
 ```
 f_score = 2*(precision*recall)/(precision + recall)
 run_logger.log("Fscore", f_score)
 run_logger.log("MaxFscore", max(f_score))
 print ("Max F_1 is {}".format(max(f_score)))
 ```
-2. Return to the Workbench and go the the **Runs** tab and click on **All Runs**. Scroll down to the table listing all the runs, click on the checkbox next to `RUN NUMBER` to select them all and click on **Archive**. Repeat this until all the runs have been archived.
 
-   ![](./images/archive-runs.jpg){:height="600px"}
+Return to the Workbench and go the the **Runs** tab and click on **All Runs**. Scroll down to the table listing all the runs, click on the checkbox next to `RUN NUMBER` to select them all and click on **Archive**. Repeat this until all the runs have been archived.
 
-3. From the **Command Prompt** rerun `python run.py` and go to the **Jobs** pannel to monitor jobs as they are running. Once all the jobs are finish running, click on the green **Completed** button to view their output. Find the job with regularization rate 0.009765625 and report its maximum F-score (under `Max F_1 is ...`). The output on this page is produced as a result of `print` statements in the script (or functions that return output). 
+![](./images/archive-runs.jpg){:height="600px"}
 
-   ![](./images/printed-output.jpg){:height="700px"}
+From the **Command Prompt** rerun `python run.py` and go to the **Jobs** pannel to monitor jobs as they are running. Once all the jobs are finish running, click on the green **Completed** button to view their output. Find the job with regularization rate 0.009765625 and report its maximum F-score (under `Max F_1 is ...`). The output on this page is produced as a result of `print` statements in the script (or functions that return output). 
 
-   For the same run, now click on the blue link just above the green **Completed** button to see the **Run Properties** pane. Find the regularization rate and the F-score in this tab. The output in this pane is created partly as a result of meta-data collected for each job (such as **Start Time** and **Duration**) and partly as a result of metrics that we logged using the `run_logger.log` function. 
+![](./images/printed-output.jpg){:height="700px"}
 
-   ![](./images/run-properties.jpg){:height="700px"}
+For the same run, now click on the blue link just above the green **Completed** button to see the **Run Properties** pane. Find the regularization rate and the F-score in this tab. The output in this pane is created partly as a result of meta-data collected for each job (such as **Start Time** and **Duration**) and partly as a result of metrics that we logged using the `run_logger.log` function. 
 
-   Scroll down to see the visuals created by array we logged, including the `Fscore` visual that should now also appear.
+![](./images/run-properties.jpg){:height="700px"}
 
-   ![](./images/array-visuals.jpg){:height="600px"}
+Scroll down to see the visuals created by array we logged, including the `Fscore` visual that should now also appear.
 
-   Scroll further down to look at visualizations created by the Python script itself. These visualizations were not explicitly logged, but they are also tracked and presented here.
+![](./images/array-visuals.jpg){:height="600px"}
 
-   ![](./images/python-visualizations.jpg){:height="700px"}
+Scroll further down to look at visualizations created by the Python script itself. These visualizations were not explicitly logged, but they are also tracked and presented here.
 
-4. Click on **All Runs** from the **Runs** tab and click on the little settings icon on the right.
+![](./images/python-visualizations.jpg){:height="700px"}
 
-   ![](./images/run-settings.jpg){:height="700px"}
+Click on **All Runs** from the **Runs** tab and click on the little settings icon on the right.
+
+![](./images/run-settings.jpg){:height="700px"}
    
-   In the window that opens, put a check mark in the box next to `MaxFscore` then click on **Apply**.
+In the window that opens, put a check mark in the box next to `MaxFscore` then click on **Apply**.
 
-   ![](./images/checkmark-fscore.jpg){:height="400px"}
+![](./images/checkmark-fscore.jpg){:height="400px"}
 
-   You should now see an additional plot showing the value for `MaxFscore` accross the different runs.
-5. Choose the two models with the highest `MaxFscore` (simply click on the two highest point on the chart). Notice how doing so automatically selects them in the table with all the runs just below the chart. Now click on the **Compare** button to compare the two models.
+You should now see an additional plot showing the value for `MaxFscore` accross the different runs.
 
-   ![](./images/max-fscore.jpg){:height="700px"}
+Choose the two models with the highest `MaxFscore` (simply click on the two highest point on the chart). Notice how doing so automatically selects them in the table with all the runs just below the chart. Now click on the **Compare** button to compare the two models.
+
+![](./images/max-fscore.jpg){:height="700px"}
    
-   Of the two models, find the one with the highest accuracy (you will find accuracy under **Logged Metrics**) and note its `runNumber` (at the very top). Then click on **Run List** to return to the table of all the runs and this time click on the `RUN NUMBER` for that model.
-6. In **Run Properties** under **Outputs** select the binary object that stores our model (called `model.pkl` by the script) and click on **Promote**.
+Of the two models, find the one with the highest accuracy (you will find accuracy under **Logged Metrics**) and note its `runNumber` (at the very top). Then click on **Run List** to return to the table of all the runs and this time click on the `RUN NUMBER` for that model.
 
-   ![](./images/promote-model.jpg){:height="700px"}
+In **Run Properties** under **Outputs** select the binary object that stores our model (called `model.pkl` by the script) and click on **Promote**.
+
+![](./images/promote-model.jpg){:height="700px"}
    
-   Click on **Project Dashboard** and then on the project path at the top. 
+Click on **Project Dashboard** and then on the project path at the top. 
 
-   ![](./images/project-dashboard.jpg){:height="500px"}
+![](./images/project-dashboard.jpg){:height="500px"}
 
-   A Windows Explorer window will open. From there go to the `classifying_iris` folder. When we promote a model, a new folder is created in our project directory called `assets` (if there was none before) and a link to the `model.pkl` is placed there, called `model.pkl.link`. The model object can also be directly downloaded using the **Download** button under **Outputs** in **Run Properties**. Once we have the model object, we can use it to create a scoring script.  
-   Promoted models are registered and versioned in our **Azure Model Management** account and can be viewed in the Azure portal under the Model Management portal. This link can be used to later download the model object itself. 
+A Windows Explorer window will open. From there go to the `classifying_iris` folder. When we promote a model, a new folder is created in our project directory called `assets` (if there was none before) and a link to the `model.pkl` is placed there, called `model.pkl.link`. The model object can also be directly downloaded using the **Download** button under **Outputs** in **Run Properties**. Once we have the model object, we can use it to create a scoring script.  
 
-   ![](./images/models-in-mm-portal.jpg){:height="600px"}
+Promoted models are registered and versioned in our **Azure Model Management** account and can be viewed in the Azure portal under the Model Management portal. This link can be used to later download the model object itself. 
 
-   Later registered models can be used to create a scoring service. We learn more about this and the Model Management portal in later labs.
-7. Before we finish this lab, let's just briefly go over how to programmatically do what we did above by using the Azure CLI instead of the Workbench GUI. Go to **File > Open Command Prompt** from Workbench and enter `az ml history list -o table` to get the history of runs. Select a particular run by copying its `Run_id` then paste it into the following command to see artifacts from a given run:
-``` 
+![](./images/models-in-mm-portal.jpg){:height="600px"}
+
+Later registered models can be used to create a scoring service. We learn more about this and the Model Management portal in later labs.
+
+Before we finish this lab, let's just briefly go over how to programmatically do what we did above by using the Azure CLI instead of the Workbench GUI. Go to **File > Open Command Prompt** from Workbench and enter `az ml history list -o table` to get the history of runs. Select a particular run by copying its `Run_id` then paste it into the following command to see artifacts from a given run:
+
+```
 az ml history info --run <run_id> --artifact driver_log
 ```
-The resulting output matches the output we saw when clicking on the green **Completed** button of a given run.  
-To promote a model object, we simply run
+
+The resulting output matches the output we saw when clicking on the green **Completed** button of a given run. To promote a model object, we simply run
+
 ```
 az ml history promote --run <run_id> --artifact-path outputs/model.pkl --name model.pkl
 ```
-The model object is assumed to be in `outputs/model.pkl` in the above command. The name given to the model object in the Model Management portal will also `model.pkl`. If models with this name is already in the Model Management portal, then each additional one will appear with a new version so that scoring services can later be rolled back to older models if need be.  
-A promoted model object can be downloaded (and put in a folder called `output`) using the following command:
+
+The model object is assumed to be in `outputs/model.pkl` in the above command. The name given to the model object in the Model Management portal will also `model.pkl`. If models with this name is already in the Model Management portal, then each additional one will appear with a new version so that scoring services can later be rolled back to older models if need be. A promoted model object can be downloaded (and put in a folder called `output`) using the following command:
+
 ```
 az ml asset download --link-file assets/model.pkl.link -d outputs
 ```
+
 We will cover model management in greater detail in later labs.

--- a/lab03.3_manage_conda_envs_in_aml/0_README.md
+++ b/lab03.3_manage_conda_envs_in_aml/0_README.md
@@ -8,112 +8,134 @@ In the context of Python, Conda is similar to `pip` and can be used to install a
 
 With Azure ML Workbench projects, we use Docker for managing system requirements and dependencies between compute environments (local, remote, Spark). Within Docker itself, we use Conda to manage Python dependencies for a given project. We use the command line `conda` command to interact with `conda` (in the case of Python, we also have some control in Jupyter notebooks)
 
-CRITICAL NOTE: By default, conda is not used for local script runs -- local runs by default will use the ``root'' python environment instead. This can problems if you work on multiple projects, as different projects may have different types of dependencies. As a general rule, it is better to use Docker even when working locally.
+CRITICAL NOTE: By default, conda is not used for local script runs -- local runs by default will use the `root` python environment instead. This can problems if you work on multiple projects, as different projects may have different types of dependencies. As a general rule, it is better to use Docker even when working locally.
 
-1. Open the Workbench and create a new project called `hello_bootcamp`, make it a blank project and place it in the `Documents` folder. Open the project and go to **File > Open Command Prompt** to access the command line from within the project parent folder. Type `python`, then in the python console paste this in:
+Open the Workbench and create a new project called `hello_bootcamp`, make it a blank project and place it in the `Documents` folder. Open the project and go to **File > Open Command Prompt** to access the command line from within the project parent folder. Type `python`, then in the python console paste this in:
 
-    ```
-    import sys
-    print(sys.executable)
+```
+import sys
+print(sys.executable)
 
-    import matplotlib
-    print("matplotlib version:", matplotlib.__version__)
-    ```
-    Note the path to the Python executable and the `matplotlib` version. Now type `exit()` to leave the Python console and return to the command prompt.  
-    If working locally without the use of Conda environments, we would be using our local root Python installation, which means that all projects would rely on the same environment and where conflicting dependencies can cause collusion, and where missing system dependencies can cause headaches when going from development to staging or production. Therefore, if working locally it is still better to leverage Docker (and Conda within Docker) instead of relying on the root Python executable as we did above. Let's now see how we can do this.
-2. To see if Conda is installed, type `conda --version`. Now type `conda list` to see a listing of installed python packages. Some of these packages are installed using `pip` or `easy_install`, some are installed using `conda install`.
-3. Open the project with Code by going to **File > Open Project (Code)**. Open the `conda_dependencies.yml` file and examine the content. What package dependencies are specified here? Add `matplotlib==2.0.2` to the list of dependencies for this project then save the file.
-4. To create a Conda environment, return to the command prompt and type
+import matplotlib
+print("matplotlib version:", matplotlib.__version__)
+```
 
-    ```
-    conda env create -f aml_config/conda_dependencies.yml
-    ```
-    which creates an environment called `project_environment` by default (we can rename it using the `-n` switch, or by changing the 'name' field in the `conda_dependencies.yml` file). Once an environment is created, it needs to be activated by running `activate project_environment`. Activate the environment and run `python`. Then in the python console type 
+Note the path to the Python executable and the `matplotlib` version. Now type `exit()` to leave the Python console and return to the command prompt.  
 
-    ```
-    import sys
-    print(sys.executable)
+If working locally without the use of Conda environments, we would be using our local root Python installation, which means that all projects would rely on the same environment and where conflicting dependencies can cause collusion, and where missing system dependencies can cause headaches when going from development to staging or production. Therefore, if working locally it is still better to leverage Docker (and Conda within Docker) instead of relying on the root Python executable as we did above. Let's now see how we can do this.
 
-    import matplotlib
-    print("matplotlib version:", matplotlib.__version__)
-    ```
-    Compare the path to the Python executable and the `matplotlib` version to the one we obtained earlier. Type `exit()` to return from the Python console to the command line.  
-5. To deactivate an environment simply type `deactivate`. Note that an environment is only active for the open Command Prompt session and will be deactivated if we close the session. We can also permanently remove this environment using `conda env remove -n project_environment`. Deactivate and remove the Conda environment.
+To see if Conda is installed, type `conda --version`. Now type `conda list` to see a listing of installed python packages. Some of these packages are installed using `pip` or `easy_install`, some are installed using `conda install`.
+
+Open the project with Code by going to **File > Open Project (Code)**. Open the `conda_dependencies.yml` file and examine the content. What package dependencies are specified here? Add `matplotlib==2.0.2` to the list of dependencies for this project then save the file.
+
+To create a Conda environment, return to the command prompt and type
+
+```
+conda env create -f aml_config/conda_dependencies.yml
+```
+
+which creates an environment called `project_environment` by default (we can rename it using the `-n` switch, or by changing the 'name' field in the `conda_dependencies.yml` file). Once an environment is created, it needs to be activated by running `activate project_environment`. Activate the environment and run `python`. Then in the python console type 
+
+```
+import sys
+print(sys.executable)
+
+import matplotlib
+print("matplotlib version:", matplotlib.__version__)
+```
+
+Compare the path to the Python executable and the `matplotlib` version to the one we obtained earlier. Type `exit()` to return from the Python console to the command line.  
+
+To deactivate an environment simply type `deactivate`. Note that an environment is only active for the open Command Prompt session and will be deactivated if we close the session. We can also permanently remove this environment using `conda env remove -n project_environment`. Deactivate and remove the Conda environment.
+
 So far we manually created and activated Conda environments. This is useful in order to see some of what happens behind the scene when we run an experiment in Workbench. However, in practice the above steps are built-in and automatically handled by Workbench itself.
-6. Return to Code and create a new script and call it `my_script.py` then paste in the following into it:
 
-    ```
-    import sys
-    print(sys.executable)
+Return to Code and create a new script and call it `my_script.py` then paste in the following into it:
 
-    import matplotlib
-    print("matplotlib version:", matplotlib.__version__)
-    ```
-    Now save changes by going to **File > Save All**.
-7. Return to Workbench and verify that the changes are visible. To run `my_script.py` using Docker as the compute environment, we must first prepare the Docker environment. This will take a few minutes, after which, we can sumbit the experiment. Return to the command prompt run the following command: 
+```
+import sys
+print(sys.executable)
 
-    ```
-    az ml experiment prepare -c docker
-    ```
-    The above command prepares a new Docker image that we can run our experiment in. We can directly access this image by typing `docker image list` and copying the name of the image (the one prefixed with `azureml_`). Then we type `docker run -it <image_name>` which puts us directly inside the command line of the Docker image. In here we can type `python` to launch a Python session and paste in the same Python code from above to check the Python executable path and the `matplotlib` version. We can then type `exit()` to leave the Python console and type `exit` to leave the Docker shell and return to the main command prompt. Manually logging into the Docker environment is tedious and not necessary in most cases. Instead we can run the following command to directly run the script in the Conda environment inside the Docker image.
+import matplotlib
+print("matplotlib version:", matplotlib.__version__)
+```
 
-    ```
-    az ml experiment submit -c docker my_script.py
-    ```
-8. In the Workbench, go to the **Jobs** panel on the right and click on the green **Completed** button to see any results printed by the script. Does the `matplotlib` version number match the version number in `conda_dependencies.yml`?
+Now save changes by going to **File > Save All**.
+
+Return to Workbench and verify that the changes are visible. To run `my_script.py` using Docker as the compute environment, we must first prepare the Docker environment. This will take a few minutes, after which, we can sumbit the experiment. Return to the command prompt run the following command: 
+
+```
+az ml experiment prepare -c docker
+```
+
+The above command prepares a new Docker image that we can run our experiment in. We can directly access this image by typing `docker image list` and copying the name of the image (the one prefixed with `azureml_`). Then we type `docker run -it <image_name>` which puts us directly inside the command line of the Docker image. In here we can type `python` to launch a Python session and paste in the same Python code from above to check the Python executable path and the `matplotlib` version. We can then type `exit()` to leave the Python console and type `exit` to leave the Docker shell and return to the main command prompt. Manually logging into the Docker environment is tedious and not necessary in most cases. Instead we can run the following command to directly run the script in the Conda environment inside the Docker image.
+
+```
+az ml experiment submit -c docker my_script.py
+```
+
+In the Workbench, go to the **Jobs** panel on the right and click on the green **Completed** button to see any results printed by the script. Does the `matplotlib` version number match the version number in `conda_dependencies.yml`?
 Conda creates an execution environment for our project and binds our Python scripts and their dependencies so that its execution environment can be isolated from that of other projects. By submitting the above command, we created a Docker image with our project and used Conda to handle the script and its dependencies, which Conda does by creating a new "environment" for the project. We created a Conda environment automatically in the last step is because in the `aml_config/docker.runconfig` file we point to `conda_dependencies.yml` and we set `PrepareEnvironment: true`.
-9. Most of us do not develop or test our Python scripts from the Python console. Instead we prefer to use an IDE like Code or Jupyter Notebooks. To launch a Jupyter notebook session for a given project, return to the command prompt and run `az ml notebook start`. This will open up a browser session (`localhost:8888`) and present our project parent directory. On the right side, click on **New** and examine the content of the dropdown. It should include `hello_bootcamp local` and `hello_bootcamp docker` with are the Conda environments associated with our project. Click on `hello_bootcamp docker` and paste in the following code in the cell of the new Jupyter notebook that opens.
 
-    ```
-    import sys
-    print(sys.executable)
+Most of us do not develop or test our Python scripts from the Python console. Instead we prefer to use an IDE like Code or Jupyter Notebooks. To launch a Jupyter notebook session for a given project, return to the command prompt and run `az ml notebook start`. This will open up a browser session (`localhost:8888`) and present our project parent directory. On the right side, click on **New** and examine the content of the dropdown. It should include `hello_bootcamp local` and `hello_bootcamp docker` with are the Conda environments associated with our project. Click on `hello_bootcamp docker` and paste in the following code in the cell of the new Jupyter notebook that opens.
 
-    import matplotlib
-    print("matplotlib version:", matplotlib.__version__)
-    ```
-    Check the `matplotlib` version and the Python executable path and confirm that it matches what we earlier.  
-    As we saw above, leveraging Docker and Conda gives us the ideal environment to run our projects, and we can leverage them both from the command line and Jupyter. However, Docker is not always available on Windows machines. On the DSVM for example, we need to use `DX_v3` instances (and enable Hyper-V) in order be able to install and use Docker. When docker is not an option and we can only work locally, then we can (and definitely should) still use Conda. Let's see how this can be done.
-9. From the command prompt, create a new Conda environment by pointing to `conda_dependencies.yml` and use `-n hello_env` to rename it from `project_environment` to `hello_env` (renaming the Conda environment is an optional step). Go to the `aml_config/local.compute` file and point the Python location from the root Python directory to the Python directory specific to this environment. You can do so by replacing `pythonLocation: "python"` with `pythonLocation: "%USERPROFILE%/AppData/Local/amlworkbench/Python/envs/hello_env/python.exe"`. To make sure that this works, run `my_script.py` locally and inspect the results generated by the script (just as we did in step 3). 
-10. It is likely that the run in the last step fails because some AML dependencies are not properly set up in the `hello_env` environment. Create a new file called `localenv_conda_dependencies.yml` and place it in `aml_config`. Place the following content inside of it and save it:
+```
+import sys
+print(sys.executable)
 
-    ```
-    # Conda environment specification. The dependencies defined in this file will be
-    # automatically provisioned for runs against docker, VM, and HDI cluster targets.
+import matplotlib
+print("matplotlib version:", matplotlib.__version__)
+```
 
-    # Details about the Conda environment file format:
-    # https://conda.io/docs/using/envs.html#create-environment-file-by-hand
+Check the `matplotlib` version and the Python executable path and confirm that it matches what we earlier.  
+As we saw above, leveraging Docker and Conda gives us the ideal environment to run our projects, and we can leverage them both from the command line and Jupyter. However, Docker is not always available on Windows machines. On the DSVM for example, we need to use `DX_v3` instances (and enable Hyper-V) in order be able to install and use Docker. When docker is not an option and we can only work locally, then we can (and definitely should) still use Conda. Let's see how this can be done.
 
-    # For Spark packages and configuration, see spark_dependencies.yml.
+From the command prompt, create a new Conda environment by pointing to `conda_dependencies.yml` and use `-n hello_env` to rename it from `project_environment` to `hello_env` (renaming the Conda environment is an optional step). Go to the `aml_config/local.compute` file and point the Python location from the root Python directory to the Python directory specific to this environment. You can do so by replacing `pythonLocation: "python"` with `pythonLocation: "%USERPROFILE%/AppData/Local/amlworkbench/Python/envs/hello_env/python.exe"`. To make sure that this works, run `my_script.py` locally and inspect the results generated by the script (just as we did in step 3). 
 
-    name: hello_env
-    dependencies:
-      - python=3.5.2
-      - ipykernel=4.6.1
-      - matplotlib==2.0.2
-      ## needed by AML:
-      - psutil=5.2.2
-      ## needed by azureml.logging below. If left off here, pip tries to build it from source. Common compiler issues make it easier to install with conda rather than pip (on windows):
-      - scipy=0.18.1
+It is likely that the run in the last step fails because some AML dependencies are not properly set up in the `hello_env` environment. Create a new file called `localenv_conda_dependencies.yml` and place it in `aml_config`. Place the following content inside of it and save it:
 
-      - pip:
-        # The API for Azure Machine Learning Model Management Service.
-        - azure-ml-api-sdk==0.1.0a10
+```
+# Conda environment specification. The dependencies defined in this file will be
+# automatically provisioned for runs against docker, VM, and HDI cluster targets.
 
-        # aml specific:
-        - https://azuremldownloads.blob.core.windows.net/wheels/latest/azureml.assets-1.0.0-py3-none-any.whl?sv=2016-05-31&si=ro-2017&sr=c&sig=xnUdTm0B%2F%2FfknhTaRInBXyu2QTTt8wA3OsXwGVgU%2BJk%3D
-        - https://azuremldownloads.blob.core.windows.net/wheels/latest/azureml.logging-1.0.79-py3-none-any.whl?sv=2016-05-31&si=ro-2017&sr=c&sig=xnUdTm0B%2F%2FfknhTaRInBXyu2QTTt8wA3OsXwGVgU%2BJk%3D
-        # note the version number of AML is in the whl name:
-        - https://azuremldownloads.blob.core.windows.net/wheels/latest/azureml.dataprep-0.1.1711.15323-py3-none-any.whl?sv=2016-05-31&si=ro-2017&sr=c&sig=xnUdTm0B%2F%2FfknhTaRInBXyu2QTTt8wA3OsXwGVgU%2BJk%3D
-        - applicationinsights==0.11.0
-    ```
-    Notice in the above file we refer directly to the Conda environment using `name: hello_env`. In `aml_config/local.runconfig` change the `CondaDependenciesFile` to point to `"aml_config/localenv_conda_dependencies.yml"` instead. As noted above, AML does not use this field for local runs. In spite of that, it's useful to make sure that the documents are consistent within a project. Additionally, it's useful to note the differences between `conda_dependencies.yml` and `localenv_conda_dependencies.yml`. The delta between those files correspond to dependencies that AML takes care of automatically when generating a docker image for experiment execution. 
-11. Return to the command prompt and remove your Conda environment `hello_env` using the following command in order to start from a clean slate:
+# Details about the Conda environment file format:
+# https://conda.io/docs/using/envs.html#create-environment-file-by-hand
 
-    ```
-    conda env remove -n hello_env
-    ```
-    Now create a new Conda environment called `hello_env` by using the  `aml_config/localenv_conda_dependencies.yml` file we just created (Note that because the new dependencies file has the `name` field appropriate defined, you do not need to use the `-n` argument).
-12. From the command line, use `az ml` to run `my_script.py` again. This time we successfully run `my_script.py` in a local Conda environment. Does the `matplotlib` package version match what we specified in `localenv_conda_dependencies.yml`?  
+# For Spark packages and configuration, see spark_dependencies.yml.
+
+name: hello_env
+dependencies:
+  - python=3.5.2
+  - ipykernel=4.6.1
+  - matplotlib==2.0.2
+  ## needed by AML:
+  - psutil=5.2.2
+  ## needed by azureml.logging below. If left off here, pip tries to build it from source. Common compiler issues make it easier to install with conda rather than pip (on windows):
+  - scipy=0.18.1
+
+  - pip:
+    # The API for Azure Machine Learning Model Management Service.
+    - azure-ml-api-sdk==0.1.0a10
+
+    # aml specific:
+    - https://azuremldownloads.blob.core.windows.net/wheels/latest/azureml.assets-1.0.0-py3-none-any.whl?sv=2016-05-31&si=ro-2017&sr=c&sig=xnUdTm0B%2F%2FfknhTaRInBXyu2QTTt8wA3OsXwGVgU%2BJk%3D
+    - https://azuremldownloads.blob.core.windows.net/wheels/latest/azureml.logging-1.0.79-py3-none-any.whl?sv=2016-05-31&si=ro-2017&sr=c&sig=xnUdTm0B%2F%2FfknhTaRInBXyu2QTTt8wA3OsXwGVgU%2BJk%3D
+    # note the version number of AML is in the whl name:
+    - https://azuremldownloads.blob.core.windows.net/wheels/latest/azureml.dataprep-0.1.1711.15323-py3-none-any.whl?sv=2016-05-31&si=ro-2017&sr=c&sig=xnUdTm0B%2F%2FfknhTaRInBXyu2QTTt8wA3OsXwGVgU%2BJk%3D
+    - applicationinsights==0.11.0
+```
+
+Notice in the above file we refer directly to the Conda environment using `name: hello_env`. In `aml_config/local.runconfig` change the `CondaDependenciesFile` to point to `"aml_config/localenv_conda_dependencies.yml"` instead. As noted above, AML does not use this field for local runs. In spite of that, it's useful to make sure that the documents are consistent within a project. Additionally, it's useful to note the differences between `conda_dependencies.yml` and `localenv_conda_dependencies.yml`. The delta between those files correspond to dependencies that AML takes care of automatically when generating a docker image for experiment execution. 
+
+Return to the command prompt and remove your Conda environment `hello_env` using the following command in order to start from a clean slate:
+
+```
+conda env remove -n hello_env
+```
+Now create a new Conda environment called `hello_env` by using the  `aml_config/localenv_conda_dependencies.yml` file we just created (Note that because the new dependencies file has the `name` field appropriate defined, you do not need to use the `-n` argument).
+
+From the command line, use `az ml` to run `my_script.py` again. This time we successfully run `my_script.py` in a local Conda environment. Does the `matplotlib` package version match what we specified in `localenv_conda_dependencies.yml`?  
+
 It bears repeating that using Conda locally is the right approach if Docker is not available, but otherwise it's better to use Conda inside a Docker image because Docker can also handle certain system dependencies that Conda wasn't built to handle.
 
 ## Conclusions

--- a/lab03.4-execute_in_remote_environment/0_README.md
+++ b/lab03.4-execute_in_remote_environment/0_README.md
@@ -3,17 +3,19 @@
 This hands-on lab guides you through executing a machine learning data preparation or model training work load in a remote environment using [Azure Machine Learning Services](https://docs.microsoft.com/en-us/azure/machine-learning/preview/overview-what-is-azure-ml) with the Azure Machine Learning Workbench. 
 
 In this workshop, you will:
+
 - Understand how to execute your workloads on remote Data Science Virtual Machines 
 - Understand how to execute your workloads on HDInsight Clusters running Spark
-- Understand how to execute your workloads on remote Data     Science VMs with GPU's
+- Understand how to execute your workloads on remote Data Science VMs with GPU's
 
-***NOTE:*** There are several pre-requisites for this course, including an understanding and implementation of: 
-  *  Programming using an Agile methodology
-  *  Machine Learning and Data Science
-  *  Intermediate to Advanced Python programming
-  *  Familiarity with Docker containers 
-  *  Familiarity with GPU Technology
-  *  Familiarity with Spark programming
+***NOTE:*** There are several pre-requisites for this course, including an understanding and implementation of:
+
+- Programming using an Agile methodology
+- Machine Learning and Data Science
+- Intermediate to Advanced Python programming
+- Familiarity with Docker containers 
+- Familiarity with GPU Technology
+- Familiarity with Spark programming
 
 There is a comprehensive Learning Path you can use to prepare for this course [located here](https://github.com/Azure/learnAnalytics-CreatingSolutionswiththeTeamDataScienceProcess-/blob/master/Instructions/Learning%20Path%20-%20Creating%20Solutions%20with%20the%20Team%20Data%20Science%20Process.md).
 
@@ -25,16 +27,17 @@ The general configuration for working with Azure Machine Learning has these comp
 ### Configuration Files
 
 When you run a script in Azure Machine Learning (Azure ML) Workbench, the behavior of the execution is controlled (usually) by files in the **aml_config** folder in your experimentation directory. 
-The files are: 
-  * ***conda_dependencies.yml*** - A conda environment file that specifies the Python runtime version and packages that your code depends on. When Azure ML Workbench executes a script in a Docker container or HDInsight cluster, it uses this file to create a conda environment for your script to run. 
-  * ***spark_dependencies.yml*** - Specifies the Spark application name when you submit a PySpark script and Spark packages that needs to be installed. You can also specify any public Maven repository or Spark package that can be found in those Maven repositories.
-  * ***compute target*** files - Specifies connection and configuration information for the compute target. It is a list of name-value pairs. ***[compute target name].compute*** contains configuration information for the following environments:
-    *  local
-    *  docker
-    *  remotedocker
-    *  cluster
-  * ***run configuration*** files - Specifies the Azure ML experiment execution behavior such as tracking run history, or what compute target to use
-    * [run configuration name].runconfig
+The files are:
+
+  - ***conda_dependencies.yml*** - A conda environment file that specifies the Python runtime version and packages that your code depends on. When Azure ML Workbench executes a script in a Docker container or HDInsight cluster, it uses this file to create a conda environment for your script to run. 
+  - ***spark_dependencies.yml*** - Specifies the Spark application name when you submit a PySpark script and Spark packages that needs to be installed. You can also specify any public Maven repository or Spark package that can be found in those Maven repositories.
+  - ***compute target*** files - Specifies connection and configuration information for the compute target. It is a list of name-value pairs. ***[compute target name].compute*** contains configuration information for the following environments:
+    - local
+    - docker
+    - remotedocker
+    - cluster
+  - ***run configuration*** files - Specifies the Azure ML experiment execution behavior such as tracking run history, or what compute target to use
+    - [run configuration name].runconfig
 
 The Azure Machine Learning Services Workbench tool combines all of these components into one location. You can use a graphical or command-line approach to managing these components.  
 
@@ -43,25 +46,10 @@ The Azure Machine Learning Services Workbench tool combines all of these compone
 ### Lab 1: Execution - Local and Docker Container
 
 In this lab you'll create an experiment, examine its configuration, and run the experiment locally, using both a `local` compute and a `docker` compute. You'll set up the experiment in the AML Workbench tool, and then run all experiments from the command line interface (CLI)
+
 - Open the Azure Machine Learning Workbench tool locally or on your Data Science Virtual Machine. 
 - Create a new experiment using the Churn example.
-- Launch the CLI. An easy way to launch the CLI is opening a project in Workbench and navigating to File-->Open Command Prompt.
-- **Authentication**: If you have not already authenticated against Azure, follow the steps below. Authentication token is cached locally for a period of time so you only need to repeat these steps when the token expires.
-
-```
-# to authenticate 
-az login
-
-# to list subscriptions
-az account list -o table
-
-# to set current subscription to a particular subscription ID 
-az account set -s <subscription_id>
-
-# to verify your current Azure subscription
-az account show
-```
-
+- Launch the CLI. An easy way to launch the CLI is opening a project in Workbench and navigating to **File > Open Command Prompt**.
 - **Execution**: Workbench enables scripts to be run directly against the Workbench-installed Python 3.5.2 runtime. This configuration is not managed by Conda unlike Docker-based executions. The package dependencies would need to be manually provisioned for your local Workbench Python environment.
 
 To run locally, run the below command:
@@ -86,10 +74,10 @@ In this lab you will create an experiment, examine its configuration, and run th
 
 - [Open this Reference and create an Ubuntu Data Science Virtual Machine](https://docs.microsoft.com/en-us/azure/machine-learning/data-science-virtual-machine/dsvm-ubuntu-intro)
 
-    - Choose a size of *Standard D4s v3 (4 vcpus, 16 GB memory)*
-    - Use a password, not a SSH Key
-    - Start the VM and connect to it using ssh. If you use some version of bash, the command is: `ssh *nameyoupicked*@*ipaddressofvm*`
-    - Check to ensure Docker is functional on your Linux DSVM with the following command:
+  - Choose a size of *Standard D4s v3 (4 vcpus, 16 GB memory)*
+  - Use a password, not a SSH Key
+  - Start the VM and connect to it using ssh. If you use some version of bash, the command is: `ssh *nameyoupicked*@*ipaddressofvm*`
+  - Check to ensure Docker is functional on your Linux DSVM with the following command:
 
 ```
 sudo docker run docker/whalesay cowsay "The best debugging is done with CTRL-X. - Buck Woody"
@@ -103,14 +91,17 @@ az ml computetarget attach remotedocker --name "remotevm" --address "remotevm_IP
 ```
 
 - Before running against "remotevm", you need to prepare it with your project's environment by running:
+
 ```
 az ml experiment prepare -c "remotevm"
 ```
 
 - Once you configure the compute target, you can use the following command to run the churn script.
+
 ```
 az ml experiment submit -c remotevm CATelcoCustomerChurnModelingWithoutDprep.py
 ```
+
 Note that the execution environment is configured using the specifications in conda_dependencies.yml.
 
 ### (Optional) Lab 3: Running on a remote Spark cluster
@@ -144,10 +135,12 @@ To run your scripts on GPU in a remote machine, you can follow the guidance in t
 ## Workshop Completion
 
 In this workshop you learned how to:
+
 - Execute your workloads on remote Data Science Virtual Machines 
 - Execute your workloads on HDInsight Clusters running Spark
 - Execute your workloads on remote Data Science VMs with GPU's
 
 You may now decommission and delete the following resources if you wish:
-  * The Azure Machine Learning Services accounts and workspaces
-  * Any Data Science Virtual Machines you have created. NOTE: Even if "Shutdown" in the Operating System, unless these Virtual Machines are "Stopped" using the Azure Portal you are incurring run-time charges. If you Stop them in the Azure Portal, you will be charged for the storage the Virtual Machines are consuming.
+
+- The Azure Machine Learning Services accounts and workspaces
+- Any Data Science Virtual Machines you have created. NOTE: Even if "Shutdown" in the Operating System, unless these Virtual Machines are "Stopped" using the Azure Portal you are incurring run-time charges. If you Stop them in the Azure Portal, you will be charged for the storage the Virtual Machines are consuming.

--- a/lab03.4-execute_in_remote_environment/0_README.md
+++ b/lab03.4-execute_in_remote_environment/0_README.md
@@ -130,7 +130,7 @@ The execution environment on HDInsight cluster is managed using Conda. Configura
 
 ### (Optional) Lab 4: Running scripts on GPU in a remote machine
 
-To run your scripts on GPU in a remote machine, you can follow the guidance in this article: [How to use GPU in Azure Machine Learning](https://docs.microsoft.com/en-us/azure/machine-learning/preview/how-to-use-gpu). Focus on the section **Configure Azure ML Workbench to Access GPU**
+To run your scripts on GPU in a remote machine, you can follow the guidance in this article: [How to use GPU in Azure Machine Learning](https://docs.microsoft.com/en-us/azure/machine-learning/preview/how-to-use-gpu). Focus on the section **Configure Azure ML Workbench to Access GPU**.
 
 ## Workshop Completion
 

--- a/lab04.1-managing_models_with_aml/0_README.md
+++ b/lab04.1-managing_models_with_aml/0_README.md
@@ -3,16 +3,18 @@
 This hands-on lab guides you through managing and regtraining models using [Azure Machine Learning Services](https://docs.microsoft.com/en-us/azure/machine-learning/preview/overview-what-is-azure-ml) with the Azure Machine Learning Workbench. 
 
 In this workshop, you will:
-- [ ] Understand Machine Learning Model versioning
-- [ ] Track models
-- [ ] Create Docker containers with the models and test them locally
 
-You'll focus on the objectives above, not Data Science, Machine Learning or a difficult scenario.  
+- Understand Machine Learning Model versioning
+- Track models
+- Create Docker containers with the models and test them locally
+
+You'll focus on the objectives above, not data science, machine learning or a difficult scenario.  
 
 ***NOTE:*** There are several pre-requisites for this course, including an understanding and implementation of: 
-  *  Programming using an Agile methodology
-  *  Machine Learning and Data Science
-  *  Working with the Microsoft Azure Portal
+
+  - Programming using an Agile methodology
+  - Machine Learning and Data Science
+  - Working with the Microsoft Azure Portal
 
 There is a comprehensive Learning Path you can use to prepare for this course [located here](https://github.com/Azure/learnAnalytics-CreatingSolutionswiththeTeamDataScienceProcess-/blob/master/Instructions/Learning%20Path%20-%20Creating%20Solutions%20with%20the%20Team%20Data%20Science%20Process.md).
 
@@ -38,9 +40,12 @@ After this lab is finished, we will have a better idea of how to use the Workben
 
 Our task in this section is to successfully run the project in a Docker container. To do so, we will need to start a new Workbench project based on an existing template and make a set of changes to the project in order to run it successfully. 
 
-1. Open the Workbench and press **CTRL+N** to create a new project. Name the project `churn_prediction` and use the `Documents` folder as the project directory. Finally, in the box called `Search Project Templates`, type `churn` and select the template called `Customer Churn Prediction`. Press **Create** to create the project.
-2. Go to **File > Open Project (Code)** to edit the project scripts using Code. Find the script `CATelcoCustomerChurnModelingWithoutDprep.py` and find the line where the data is read: `df = pd.read_csv('data/CATelcoCustomerChurnTrainingSample.csv')` to see how the raw data is read.
-3. Go to `aml_config/docker.runconfig` and replace its content with 
+Open the Workbench and press **CTRL+N** to create a new project. Name the project `churn_prediction` and use the `Documents` folder as the project directory. Finally, in the box called `Search Project Templates`, type `churn` and select the template called `Customer Churn Prediction`. Press **Create** to create the project.
+
+Go to **File > Open Project (Code)** to edit the project scripts using Code. Find the script `CATelcoCustomerChurnModelingWithoutDprep.py` and find the line where the data is read: `df = pd.read_csv('data/CATelcoCustomerChurnTrainingSample.csv')` to see how the raw data is read.
+
+Go to `aml_config/docker.runconfig` and replace its content with 
+
 ```
 ArgumentVector:
   - "$file"
@@ -53,60 +58,76 @@ SparkDependenciesFile: "aml_config/spark_dependencies.yml"
 PrepareEnvironment: true
 TrackedRun: true
 ```
-4. On Code, go to **File > Save All** to save all the above changes. Then return to the Workbench and check to make sure the changes are visible here. We can check by clicking on the **Files** tab on the left pannel and opening one of the files we changed.
-5. In order to run the experiment in a Docker container, we must prepare a Docker image. We will do so programatically by going to **File > Open Command Prompt** and typing `az ml experiment prepare -c docker`. Notice all the changes that are happening as this command is running. This should take a few minutes.
+
+On Code, go to **File > Save All** to save all the above changes. Then return to the Workbench and check to make sure the changes are visible here. We can check by clicking on the **Files** tab on the left pannel and opening one of the files we changed.
+
+In order to run the experiment in a Docker container, we must prepare a Docker image. We will do so programatically by going to **File > Open Command Prompt** and typing `az ml experiment prepare -c docker`. Notice all the changes that are happening as this command is running. This should take a few minutes.
+
 **Note:** At this point, there is a strange Docker behavior for which we propose an easy solution: we may get an error at the top about `image operating system "linux" cannot be used on this platform`.
 
-   ![](./images/linux-image-not-found.jpg){:width="500px"}
+![](./images/linux-image-not-found.jpg){:width="500px"}
 
-   To resolve it we click on the Docker logo on the right-hand side in the taskbar and switch Docker to use Windows containers. This will result in a new Docker error:
+To resolve it we click on the Docker logo on the right-hand side in the taskbar and switch Docker to use Windows containers. This will result in a new Docker error:
 
-   ![](./images/docker-windows-image.jpg){:width="400px"}
+![](./images/docker-windows-image.jpg){:width="400px"}
 
-   Now we switch Docker back to Linux containers (by going to the taskbar once more).
+Now we switch Docker back to Linux containers (by going to the taskbar once more).
 
-   ![](./images/switch-linux-containers.jpg){:width="300px"}
+![](./images/switch-linux-containers.jpg){:width="300px"}
 
-   We then return to the command prompt and run the above command again. This will take a few minutes. When finished, we should get a message saying `Your environment is now ready`.
-6. We can now run our experiment in a Docker container by submitting the following command: `az ml experiment submit -c docker CATelcoCustomerChurnModelingWithoutDprep.py`. Alternatively, we can go to the **Project Dashboard**, select "docker" as the run configuration, select the `CATelcoCustomerChurnModelingWithoutDprep.py` script and click on the run button. In either case, we should be able to see a new job starting on the **Jobs** in the pannel on the right-hand side. Click on the finished job to see the **Run Properties** such as **Duration**. Notice under **Outputs** there are no objects, so the script did not create any artifacts. Click on the green **Completed** to see any results printed by the script, including the model accuracy. It is worth noting that the Azure CLI runs on both the Windows and Linux command line. To see this in action, from the Windows command prompt type `bash` to switch to a Linux command prompt and submit `az ml experiment submit -c docker CATelcoCustomerChurnModelingWithoutDprep.py` a second time.
-7. When finished, click on the job and notice the output `model.pkl` in the **Run Properties** pane under **Outputs**. Select this output, download it and place it in root folder.
+We then return to the command prompt and run the above command again. This will take a few minutes. When finished, we should get a message saying `Your environment is now ready`.
+
+We can now run our experiment in a Docker container by submitting the following command: `az ml experiment submit -c docker CATelcoCustomerChurnModelingWithoutDprep.py`. Alternatively, we can go to the **Project Dashboard**, select "docker" as the run configuration, select the `CATelcoCustomerChurnModelingWithoutDprep.py` script and click on the run button. In either case, we should be able to see a new job starting on the **Jobs** in the pannel on the right-hand side. Click on the finished job to see the **Run Properties** such as **Duration**. Notice under **Outputs** there are no objects, so the script did not create any artifacts. Click on the green **Completed** to see any results printed by the script, including the model accuracy. It is worth noting that the Azure CLI runs on both the Windows and Linux command line. To see this in action, from the Windows command prompt type `bash` to switch to a Linux command prompt and submit `az ml experiment submit -c docker CATelcoCustomerChurnModelingWithoutDprep.py` a second time.
+
+When finished, click on the job and notice the output `model.pkl` in the **Run Properties** pane under **Outputs**. Select this output, download it and place it in root folder.
 
 ### Creating a web service out of the scoring script
 
 Let's now see how we can create a scoring web service from the above model inside a docker image. There are multiple steps that go into doing that. We will be running commands from the command line, but we will also log into the Azure portal in order to see which resources are being created as we run various Azure CLI commands.
 
-1. Enable the Azure Container Service by running `az provider register -n Microsoft.ContainerService` from the command line.
-2. Run `az group create -n azurebootcamplab43 -l eastus2` to create a resource group called `azurebootcamplab43` for the resources we will provision throughout this lab. Then run `az ml account modelmanagement create -l eastus2 -n azureuseramlmm -g azurebootcamplab43` to create a model management account.
-3. Log into the Azure portal and find all the resources under the resource group `azurebootcamplab43`. This should include an Experimentation and a Model Management account. Open the Model Management resource and click on **Model Management** icon on the top.
-4. If we're doing this for the first time, then we need to set up an environment. We usually have a staging and a production environment. We can deploy our models to the staging environment to test them and then redeploy them to the production environment once we're happy with the result. To create a new environment run the following command. To use in production, we can use --cluster:
+Enable the Azure Container Service by running `az provider register -n Microsoft.ContainerService` from the command line.
+
+Run `az group create -n azurebootcamplab43 -l eastus2` to create a resource group called `azurebootcamplab43` for the resources we will provision throughout this lab. Then run `az ml account modelmanagement create -l eastus2 -n azureuseramlmm -g azurebootcamplab43` to create a model management account.
+
+Log into the Azure portal and find all the resources under the resource group `azurebootcamplab43`. This should include an Experimentation and a Model Management account. Open the Model Management resource and click on **Model Management** icon on the top.
+
+If we're doing this for the first time, then we need to set up an environment. We usually have a staging and a production environment. We can deploy our models to the staging environment to test them and then redeploy them to the production environment once we're happy with the result. To create a new environment run the following command. To use in production, we can use --cluster:
+
 ```
 az ml env setup -l eastus2 -n bootcampvmstage -g azurebootcamplab43
 ```
+
 We can look at all the environments uder our subscription using `az ml env list -o table`. Creating the new environment takes about one minute, after which we can activate it and show it using this:
+
 ```
 az ml env set -n bootcampvmstage -g azurebootcamplab43
 az ml env show
 ```
-5. We next set our Model Management account by running this:
+
+We next set our Model Management account by running this:
+
 ```
 az ml account modelmanagement set -n azureuseramlmm -g azurebootcamplab43
 ```
-6. We are now finally ready to deploy our model as a web service. 
+
+We are now finally ready to deploy our model as a web service. 
 
 Generate the schema by first running ```python churn_schema_gen.py```. We can then create a realtime service by running `az ml service create realtime -n churnpred --model-file ./model.pkl -f score.py -r python -s service_schema.json`. Notice the three steps that take place as the command is running. First we register the model, then we create a manifest, then we create a Docker image, and finally we initialize a Docker container that services our prediction app. We can go to the Azure portal and go to click on the resource named `azureuseramlmm` under the resource group `azurebootcamplab43`, then click on **Model Management**.
 
-   ![](./images/model-management-portal.jpg){:width="500px"}
+![](./images/model-management-portal.jpg){:width="500px"}
 
-   In the Model Management portal, we can view the three resources that are created as the above command runs: the manifest, the image, and the service. Click on each to view the resources.
+In the Model Management portal, we can view the three resources that are created as the above command runs: the manifest, the image, and the service. Click on each to view the resources.
 
-   ![](./images/model-management-services.jpg){:width="500px"}
+![](./images/model-management-services.jpg){:width="500px"}
 
 ## Workshop Completion
 
 In this workshop you learned how to:
-- [ ] Track models
-- [ ] Create Docker containers with the models and test them locally
+
+- Track models
+- Create Docker containers with the models and test them locally
 
 You may now decommission and delete the following resources if you wish:
-  * The Azure Machine Learning Services accounts and workspaces, and any Web API's
-  * Any Data Science Virtual Machines you have created. NOTE: Even if "Shutdown" in the Operating System, unless these Virtual Machines are "Stopped" using the Azure Portal you are incurring run-time charges. If you Stop them in the Azure Portal, you will be charged for the storage the Virtual Machines are consuming.
+
+  - The Azure Machine Learning Services accounts and workspaces, and any Web API's
+  - Any Data Science Virtual Machines you have created. NOTE: Even if "Shutdown" in the Operating System, unless these Virtual Machines are "Stopped" using the Azure Portal you are incurring run-time charges. If you Stop them in the Azure Portal, you will be charged for the storage the Virtual Machines are consuming.

--- a/lab04.4-collect_and_analyze_data_from_a_scoring_service/0_README.md
+++ b/lab04.4-collect_and_analyze_data_from_a_scoring_service/0_README.md
@@ -3,10 +3,12 @@
 This hands-on lab guides you through collecting Machine Learning scoring  data using [Azure Machine Learning Services](https://docs.microsoft.com/en-us/azure/machine-learning/preview/overview-what-is-azure-ml) with the Azure Machine Learning Workbench. 
 
 In this workshop, you will:
+
 - Use the Azure Machine Learning Services collection module to view scoring data from API calls
 - Use Azure Storage to view the results
 
-***NOTE:*** There are several pre-requisites for this course, including an understanding and implementation of: 
+***NOTE:*** There are several pre-requisites for this course, including an understanding and implementation of:
+
   *  Programming using an Agile methodology
   *  Machine Learning and Data Science
   *  Intermediate to Advancced Python programming
@@ -189,9 +191,11 @@ To view the collected data in blob storage:
 ## Workshop Completion
 
 In this workshop you learned how to:
+
 - Use the Azure Machine Learning Services collection module to view scoring data from API calls
 - Use Azure Storage to view the results
 
 You may now decommission and delete the following resources if you wish:
-  * The Azure Machine Learning Services accounts and workspaces
-  * Any Data Science Virtual Machines you have created. NOTE: Even if "Shutdown" in the Operating System, unless these Virtual Machines are "Stopped" using the Azure Portal you are incurring run-time charges. If you Stop them in the Azure Portal, you will be charged for the storage the Virtual Machines are consuming.
+
+- The Azure Machine Learning Services accounts and workspaces
+- Any Data Science Virtual Machines you have created. NOTE: Even if "Shutdown" in the Operating System, unless these Virtual Machines are "Stopped" using the Azure Portal you are incurring run-time charges. If you Stop them in the Azure Portal, you will be charged for the storage the Virtual Machines are consuming.

--- a/lab04.5-parallel_hyperparameter_sweeps_on_spark/0_README.md
+++ b/lab04.5-parallel_hyperparameter_sweeps_on_spark/0_README.md
@@ -2,40 +2,45 @@
 
 In this lab, we will use the Azure CLI to provision and configure a HDI Spark cluster and use Docker containers on it to run parameter sweep for a given model. Parameter sweep is more commonly known as hyper-parameter tuning. A hyper-parameter is any model input that cannot be directly learned from data and must instead be declared (or guessed) by the data scientist. In order to choose good hyper-parameter values data scientists rely in some cases on no more than some basic rules of thumb and lots of trial and error. Most models have not one but many hyper-parameters and therefore finding a good combination of hyper-parameters (using grid search for example) is a very iterative process. When we "tune" (roughly optimize) our hyper-parameters we train models with different values for hyper-parameters each time and choose the that works best. It is therefore essential to be able to run multiple models efficiently and concurrently. Spark clusters are a good place to perform parameter sweep because we can run many jobs in parallel and let Spark handle the load-balancing and management.
 
-1. Open the Azure ML Workbench and start a new project called `parameter_sweep` under `Documents` and make it use the **Parameter Sweep on Spark** as template. Place the new project in **Documents**. Open the project and go to **File > Open Command Prompt**. To create a Spark cluster we will use the template found [here](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F101-hdinsight-spark-linux%2Fazuredeploy.json) and the Azrue CLI. The credentials to log into the cluster along with some other information is stored in `parameters-hdi.json`. To provision the cluster, first copy the files `template-hdi.json` and `parameters-hdi.json` into the project directory. we simply run the command below (if we do not wish to store passwords in the file, we can remove them and instead we will be prompted to enter a password when we run the command). If the commands below fails (a likely scenario) it is likely to be because of you need to rename your storage account (storage account names must be unique in each region). Change the commands below and go into `template-hdi.json` to make the appropriate changes and rerun the commands. In case the last command fails for less predictable reasons, please refer to [this link](https://docs.microsoft.com/en-us/azure/hdinsight/spark/apache-spark-jupyter-spark-sql) to provision an HDI cluster from the Azure portal.
-```
-az group create -n azurebootcamplab41 -l eastus2
-az storage account create -n azbcsparkeastus2 -g azurebootcamplab41 --sku Standard_LRS
-az group deployment create -g azurebootcamplab41 --template-file template-hdi.json --parameters @parameters-hdi.json
-```
-2. Type the following commands to prepare the docker environment and the Spark cluster to run our jobs.
+Open the Azure ML Workbench and start a new project called `parameter_sweep` under `Documents` and make it use the **Parameter Sweep on Spark** as template. Place the new project in **Documents**. Open the project and go to **File > Open Command Prompt**. To create a Spark cluster please refer to [this link](https://docs.microsoft.com/en-us/azure/hdinsight/spark/apache-spark-jupyter-spark-sql) to provision an HDI cluster from the Azure portal.
+
+Type the following commands to prepare the docker environment and the Spark cluster to run our jobs.
+
 ```
 az ml experiment prepare -c docker
 ```
+
 **Note:** At this point, there is a strange Docker behavior for which we propose an easy solution: we may get an error at the top about `image operating system "linux" cannot be used on this platform`.
 
-   ![](./images/linux-image-not-found.jpg){:width="500px"}
+![](./images/linux-image-not-found.jpg){:width="500px"}
 
-   To resolve it we click on the Docker logo on the right-hand side in the taskbar and switch Docker to use Windows containers. This will result in a new Docker error:
+To resolve it we click on the Docker logo on the right-hand side in the taskbar and switch Docker to use Windows containers. This will result in a new Docker error:
 
-   ![](./images/docker-windows-image.jpg){:width="400px"}
+![](./images/docker-windows-image.jpg){:width="400px"}
 
-   Now we switch Docker back to Linux containers (by going to the taskbar once more).
+Now we switch Docker back to Linux containers (by going to the taskbar once more).
 
-   ![](./images/switch-linux-containers.jpg){:width="300px"}
+![](./images/switch-linux-containers.jpg){:width="300px"}
 
-   We then return to the command prompt and run the above command again. This will take a few minutes. When finished, we should get a message saying `Your environment is now ready`.
-3. Return to the Workbench and go to **File > Open Project (Code)** to open it using Code. Examine the script `sweep_spark.py`. Find the learning algorithm we're using and the set of hyper-parameters that we want to optimize over and their ranges.
-4. Now we specify the Spark cluster as the compute target by running the following command.
+We then return to the command prompt and run the above command again. This will take a few minutes. When finished, we should get a message saying `Your environment is now ready`.
+
+Return to the Workbench and go to **File > Open Project (Code)** to open it using Code. Examine the script `sweep_spark.py`. Find the learning algorithm we're using and the set of hyper-parameters that we want to optimize over and their ranges.
+
+Now we specify the Spark cluster as the compute target by running the following command.
 The command may return an error message about having to prepare the environment first, even though the previous command should have been prepared the environment already. Running the rest of the code still works and the error message can safely be ignored.
+
 ```
 az ml computetarget attach cluster --name azbootcamphdispark --address azbootcamphdispark-ssh.azurehdinsight.net --username sshuser --password DataScience2017!
 az ml experiment prepare -c azbootcamphdispark
 ```
+
 This will create the files `aml_config/azbootcamphdispark.compute` and `aml_config/azbootcamphdispark.runconfig`. We now have a pair of such files for local, Docker and one for Spark.
-5. Finally, we can now run the job. We will first run it in Docker, which is great for debugging purposes and working locally while we're still in development mode. To do so just run this on the command line:
+Finally, we can now run the job. We will first run it in Docker, which is great for debugging purposes and working locally while we're still in development mode. To do so just run this on the command line:
+
 ```
 az ml experiment submit -c docker .\sweep_spark.py
 ```
+
 If we were able to run the Docker example successfully, we can now see if we can replicate it in Spark. To do so simply replace `docker` with `azbootcamphdispark` in the above command and rerun it. If the Docker run failed, we may need to swich Docker to a Windows context (by right-clicking on the Docker icon in the taskbar) and upon getting an error message, switch it back to a Linux context and then try again.
-6. Report the accuracy of the best model that came out of the parameter sweep.
+
+Report the accuracy of the best model that came out of the parameter sweep.


### PR DESCRIPTION
I made a pass through the labs and simplified a bunch of things. I got rid of the numeric bullets for each lab step, because it makes it easier to add intermediate steps if we have to without breaking the order, and because it makes it so we don't have to indent the code chunks or image inserts so they stay embedded in the steps, which was frankly a nightmare.

Other things I did was remove redundant steps in some of the labs, replaced programmatic deployments using templates with GUI deployments from the portal (until we fix the templates), and some other formatting issues.