### PR TITLE
Escaping markdown & character

### DIFF
--- a/lab02.2-building_bots/4_Publish_and_Register.md
+++ b/lab02.2-building_bots/4_Publish_and_Register.md
@@ -16,7 +16,7 @@ First we need to grab a few keys. Go to the Web App Bot you just created (in the
 
 Return to your PictureBot in Visual Studio. In the Web.config file, fill in the the blanks under `appSettings` with the BotId, MicrosoftAppId, and MicrosoftAppPassword. Save the file. 
 
-> Getting an error that directs you to your MicrosoftAppPassword? Because it's in XML, if your key contains "&", "<", ">", "'", or '"', you will need to replace those symbols with their respective [escape facilities](https://en.wikipedia.org/wiki/XML#Characters_and_escaping): "&amp;", "&lt;", "&gt;", "&apos;", "&quot;". 
+> Getting an error that directs you to your MicrosoftAppPassword? Because it's in XML, if your key contains "&", "<", ">", "'", or '"', you will need to replace those symbols with their respective [escape facilities](https://en.wikipedia.org/wiki/XML#Characters_and_escaping): "\&amp;", "\&lt;", "\&gt;", "\&apos;", "\&quot;". 
 
 In the Solution Explorer, right-click on your Bot Application project and select "Publish".  This will launch a wizard to help you publish your bot to Azure.  
 


### PR DESCRIPTION
The XML escape facilities are rendered in markdown as HTML characters, so they don't show the XML escape facilities correctly. By placing a \ in front of &, it will be rendered correctly.